### PR TITLE
Fe/#56/style edit

### DIFF
--- a/frontend/src/components/Common/Button.tsx
+++ b/frontend/src/components/Common/Button.tsx
@@ -2,7 +2,14 @@ import React from "react";
 import classNames from "classnames";
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  scheme?: "primary" | "secondary" | "close" | "tab" | "custom";
+  scheme?:
+    | "primary"
+    | "secondary"
+    | "close"
+    | "tab"
+    | "custom"
+    | "reset"
+    | "apply";
   size?: "small" | "medium" | "large" | "icon" | "semi";
   isLoading?: boolean;
   fullWidth?: boolean;
@@ -31,10 +38,13 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         "bg-primary1 text-white border border-primary1 hover:bg-primary5 hover:border-primary5",
       secondary:
         "bg-white text-primary5 border border-primary5 hover:bg-primary5 hover:border-primary5 hover:text-white",
-
       close: "text-gray-400 hover:text-primary5",
       tab: "bg-transparent text-gray-400 hover:text-primary5 border-b-2 border-transparent",
       custom: "",
+      apply:
+        "bg-primary5 text-white border border-primary5 shadow-none hover:shadow-none hover:text-white hover:brightness-95",
+      reset:
+        "bg-white text-primary5 border border-primary5 hover:bg-primary4 hover:text-primary5 hover:border-primary5",
     };
 
     const sizeStyle = {

--- a/frontend/src/components/RestaurantDetail/RestaurantDetail.tsx
+++ b/frontend/src/components/RestaurantDetail/RestaurantDetail.tsx
@@ -56,7 +56,7 @@ export default function RestaurantDetailComponent({
       })
       .catch(() => setError("상세 정보를 불러오지 못했습니다."))
       .finally(() => setLoading(false));
-  }, [storeId]);
+  }, [storeId, setPosition, setRestaurants, setRefreshBtn]);
 
   const handleToggleFavorite = async () => {
     if (!isLoggedIn) {

--- a/frontend/src/components/RestaurantDetail/RestaurantDetailBroadcastTab.tsx
+++ b/frontend/src/components/RestaurantDetail/RestaurantDetailBroadcastTab.tsx
@@ -34,6 +34,7 @@ function compareDate(a: string, b: string): number {
 interface RestaurantDetailBroadcastTabProps {
   detail: RestaurantDetail;
   storeId: number;
+  onManage?: () => void;
 }
 
 export default function RestaurantDetailBroadcastTab({

--- a/frontend/src/components/RestaurantDetail/RestaurantDetailBroadcastTab.tsx
+++ b/frontend/src/components/RestaurantDetail/RestaurantDetailBroadcastTab.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useState } from "react";
-import { FiTv, FiChevronDown, FiChevronUp } from "react-icons/fi";
+import { FiTv, FiChevronDown, FiChevronUp, FiVolume2 } from "react-icons/fi";
 import Button from "../Common/Button";
 import type { RestaurantDetail, Broadcast } from "../../types/restaurant.types";
 import EmptyMessage from "./EmptyMessage";
@@ -12,13 +12,11 @@ function getKoreanDateString(dateStr: string): string {
   return `${date.getMonth() + 1}월 ${date.getDate()}일`;
 }
 
-// 시간에서 초 제거 ("HH:mm:ss" -> "HH:mm")
 function formatTime(timeStr: string | undefined | null): string {
   if (!timeStr) return "";
   return timeStr.split(":").slice(0, 2).join(":");
 }
 
-// 날짜별 그룹핑
 function groupByDate(broadcasts: Broadcast[]): Record<string, Broadcast[]> {
   return broadcasts.reduce((acc, b) => {
     (acc[b.match_date] = acc[b.match_date] || []).push(b);
@@ -26,7 +24,6 @@ function groupByDate(broadcasts: Broadcast[]): Record<string, Broadcast[]> {
   }, {} as Record<string, Broadcast[]>);
 }
 
-// 날짜 비교 함수 (YYYY-MM-DD 문자열 비교)
 function compareDate(a: string, b: string): number {
   return a.localeCompare(b);
 }
@@ -41,10 +38,9 @@ export default function RestaurantDetailBroadcastTab({
   detail,
   storeId,
 }: RestaurantDetailBroadcastTabProps) {
-  const [showPast, setShowPast] = useState<boolean>(false);
+  const [showPast, setShowPast] = useState(false);
   const today: string = new Date().toISOString().slice(0, 10);
 
-  // 중계일정 분리
   const futureAndToday: Broadcast[] = [];
   const past: Broadcast[] = [];
   detail.broadcasts.forEach((b: Broadcast) => {
@@ -55,12 +51,10 @@ export default function RestaurantDetailBroadcastTab({
     }
   });
 
-  // 날짜별 그룹핑 및 정렬
   const groupedFuture: Record<string, Broadcast[]> =
     groupByDate(futureAndToday);
   const groupedPast: Record<string, Broadcast[]> = groupByDate(past);
 
-  // 날짜 오름차순(오늘~미래), 내림차순(과거)
   const sortedFutureDates: string[] = Object.keys(groupedFuture).sort((a, b) =>
     compareDate(a, b)
   );
@@ -72,16 +66,22 @@ export default function RestaurantDetailBroadcastTab({
   const { setRestaurantSubpage, setSelectedTab, setIsMypageOpen } =
     useMypageStore();
 
+  // 소개 라벨+아이콘
+  const ETC_LABEL = (
+    <span className="inline-flex items-center gap-1 text-xs font-semibold text-primary5 mr-1">
+      <FiVolume2 className="text-primary5 text-base" />
+    </span>
+  );
+
   return (
     <div>
       <ul>
-        {/* 오늘+미래 일정 */}
         {futureAndToday.length === 0 ? (
           <li>
             <EmptyMessage message="예정된 중계정보가 없습니다." />
           </li>
         ) : (
-          sortedFutureDates.map((date: string, groupIdx: number) => (
+          sortedFutureDates.map((date, groupIdx) => (
             <Fragment key={date}>
               <h4
                 className={`mb-2 ${
@@ -94,7 +94,7 @@ export default function RestaurantDetailBroadcastTab({
                   {date}
                 </span>
               </h4>
-              {groupedFuture[date].map((b: Broadcast, idx: number) => (
+              {groupedFuture[date].map((b, idx) => (
                 <li
                   key={idx}
                   className="rounded-xl p-4 mb-3 flex flex-col gap-2 border border-primary2 bg-white"
@@ -110,22 +110,32 @@ export default function RestaurantDetailBroadcastTab({
                       {formatTime(b.match_time)}
                     </span>
                   </div>
-                  <div className="flex items-center gap-2 text-base font-bold text-gray-800">
-                    {b.team_one && b.team_two ? (
-                      <>
+                  {b.team_one && b.team_two ? (
+                    <>
+                      <div className="flex items-center gap-2 text-base font-bold text-gray-800">
                         <span>{b.team_one}</span>
                         <span className="mx-1 text-primary5">vs</span>
                         <span>{b.team_two}</span>
-                      </>
-                    ) : (
-                      <></>
-                    )}
-                    {b.etc && (
-                      <span className="ml-2 text-xs bg-primary3 text-primary5 rounded px-2 py-0.5">
-                        {b.etc}
-                      </span>
-                    )}
-                  </div>
+                      </div>
+                      {b.etc && (
+                        <div className="mt-1 flex items-start gap-2 text-xs text-gray-700">
+                          {ETC_LABEL}
+                          <span className="whitespace-pre-line break-words">
+                            {b.etc}
+                          </span>
+                        </div>
+                      )}
+                    </>
+                  ) : (
+                    b.etc && (
+                      <div className="mt-1 flex items-start gap-2 text-xs text-gray-700">
+                        {ETC_LABEL}
+                        <span className="whitespace-pre-line break-words">
+                          {b.etc}
+                        </span>
+                      </div>
+                    )
+                  )}
                 </li>
               ))}
             </Fragment>
@@ -159,7 +169,7 @@ export default function RestaurantDetailBroadcastTab({
                 지난 중계정보가 없습니다.
               </li>
             ) : (
-              sortedPastDates.map((date: string, groupIdx: number) => (
+              sortedPastDates.map((date, groupIdx) => (
                 <Fragment key={date}>
                   <h4
                     className={`mb-2 ${
@@ -172,7 +182,7 @@ export default function RestaurantDetailBroadcastTab({
                       {date}
                     </span>
                   </h4>
-                  {groupedPast[date].map((b: Broadcast, idx: number) => (
+                  {groupedPast[date].map((b, idx) => (
                     <li
                       key={idx}
                       className="rounded-xl p-4 mb-3 flex flex-col gap-2 border border-gray-200 bg-gray-50"
@@ -188,22 +198,32 @@ export default function RestaurantDetailBroadcastTab({
                           {formatTime(b.match_time)}
                         </span>
                       </div>
-                      <div className="flex items-center gap-2 text-base font-bold text-gray-500">
-                        {b.team_one && b.team_two ? (
-                          <>
+                      {b.team_one && b.team_two ? (
+                        <>
+                          <div className="flex items-center gap-2 text-base font-bold text-gray-500">
                             <span>{b.team_one}</span>
-                            <span className="mx-1 text-primary5">vs</span>
+                            <span className="mx-1 text-gray-400">vs</span>
                             <span>{b.team_two}</span>
-                          </>
-                        ) : (
-                          <></>
-                        )}
-                        {b.etc && (
-                          <span className="ml-2 text-xs bg-gray-100 text-gray-400 rounded px-2 py-0.5">
-                            {b.etc}
-                          </span>
-                        )}
-                      </div>
+                          </div>
+                          {b.etc && (
+                            <div className="mt-1 flex items-start gap-2 text-xs text-gray-700">
+                              {ETC_LABEL}
+                              <span className="whitespace-pre-line break-words">
+                                {b.etc}
+                              </span>
+                            </div>
+                          )}
+                        </>
+                      ) : (
+                        b.etc && (
+                          <div className="mt-1 flex items-start gap-2 text-xs text-gray-700">
+                            {ETC_LABEL}
+                            <span className="whitespace-pre-line break-words">
+                              {b.etc}
+                            </span>
+                          </div>
+                        )
+                      )}
                     </li>
                   ))}
                 </Fragment>

--- a/frontend/src/components/RestaurantDetail/RestaurantDetailHomeTab.tsx
+++ b/frontend/src/components/RestaurantDetail/RestaurantDetailHomeTab.tsx
@@ -1,5 +1,6 @@
 import { FiMapPin, FiClock, FiPhone, FiFileText } from "react-icons/fi";
 import type { RestaurantDetail } from "../../types/restaurant.types";
+import classNames from "classnames";
 
 export default function RestaurantDetailHomeTab({
   detail,
@@ -15,8 +16,18 @@ export default function RestaurantDetailHomeTab({
           </span>
         </div>
       )}
-      <h2 className="text-2xl font-bold mb-2">{detail.store_name}</h2>
-      <p className="mb-2 text-gray-700">{detail.description}</p>
+      <h2
+        className={classNames(
+          "text-2xl font-bold",
+          // description이 없으면 mb-0, 있으면 mb-2
+          detail.description ? "mb-2" : "mb-1"
+        )}
+      >
+        {detail.store_name}
+      </h2>
+      {detail.description && (
+        <p className="mb-2 text-gray-700">{detail.description}</p>
+      )}
       <div className="flex items-center gap-2">
         <FiMapPin className="text-xl" />
         <span>{detail.address}</span>

--- a/frontend/src/components/Search/RegionModal.tsx
+++ b/frontend/src/components/Search/RegionModal.tsx
@@ -19,16 +19,16 @@ const RegionModal = ({ onClose, onApply }: RegionModalProps) => {
     <ModalBase onClose={onClose} title="지역" className="p-5">
       <RegionPanel />
       <div className="border-t border-gray-200 pt-5 flex gap-3">
-        <Button onClick={resetRegions} scheme="secondary">
+        <Button scheme="reset" onClick={resetRegions}>
           초기화
         </Button>
         <Button
+          scheme="apply"
+          className="flex-1"
           onClick={() => {
             onApply(regionLabels);
             onClose();
           }}
-          scheme="primary"
-          className="flex-1"
         >
           적용
         </Button>

--- a/frontend/src/components/Search/ResetButton.tsx
+++ b/frontend/src/components/Search/ResetButton.tsx
@@ -15,7 +15,7 @@ const ResetSearchButton = () => {
   };
 
   return (
-    <Button onClick={handleReset} scheme="secondary" fullWidth size="semi">
+    <Button onClick={handleReset} scheme="reset" fullWidth size="semi">
       초기화
     </Button>
   );

--- a/frontend/src/components/Search/SearchButton.tsx
+++ b/frontend/src/components/Search/SearchButton.tsx
@@ -50,7 +50,7 @@ const SearchButton = () => {
   };
 
   return (
-    <Button onClick={handleSearch} scheme="primary" fullWidth size="semi">
+    <Button onClick={handleSearch} scheme="apply" fullWidth size="semi">
       <SearchOutlined className="text-sm mr-2" />
       검색
     </Button>

--- a/frontend/src/components/Search/SportModal.tsx
+++ b/frontend/src/components/Search/SportModal.tsx
@@ -15,7 +15,7 @@ const SportModal = ({ onClose, onApply }: SportModalProps) => {
     <ModalBase onClose={onClose} title="경기" className="p-5">
       <SportPanel />
       <div className="border-t border-gray-200 pt-5 flex gap-3">
-        <Button onClick={resetSport} scheme="secondary">
+        <Button onClick={resetSport} scheme="reset">
           초기화
         </Button>
         <Button
@@ -28,7 +28,7 @@ const SportModal = ({ onClose, onApply }: SportModalProps) => {
             });
             onClose();
           }}
-          scheme="primary"
+          scheme="apply"
           className="flex-1"
         >
           적용


### PR DESCRIPTION
## 📎 관련 이슈
#56


## 📌 PR 설명
- 가게 소개 내용 없을 때 UI수정 (margin 줄임)
- 통합 검색 버튼 스타일 변경 (reset, apply)
- 가게 상세보기 중계탭 UI수정 (etc 하단에 배치)


## ✅ 작업 내용
- [ ] 기능 구현
- [x] UI 수정
- [ ] 버그 수정


## 🧪 테스트 방법 (선택)
어떻게 테스트했는지, 테스트할 방법이 있다면 적어주세요.


## 💬 기타
<img width="426" height="536" alt="image" src="https://github.com/user-attachments/assets/e070bf1a-4323-4dd6-b5cc-37f6823ad50e" />

<img width="407" height="367" alt="image" src="https://github.com/user-attachments/assets/a3091080-d99d-4faa-adc0-0343642416b2" />


<img width="407" height="367" alt="스크린샷 2025-07-15 143009" src="https://github.com/user-attachments/assets/65f38b2d-ceae-465e-8690-42e7dce43816" />

